### PR TITLE
Add a reference to the parent popup for the target and controller

### DIFF
--- a/src/plugins/AriaPopup.js
+++ b/src/plugins/AriaPopup.js
@@ -72,6 +72,9 @@ export default class AriaPopup extends Aria {
     this.loadOpen = this._loadOpen;
     this.isExpanded = this._loadOpen;
 
+    this.controller.popup = this;
+    this.target.popup = this;
+
     this.controller.setAttribute('aria-haspopup', 'true');
     this.controller.setAttribute('aria-expanded', `${this.loadOpen}`);
     this.controller.setAttribute('aria-controls', this.targetId);


### PR DESCRIPTION
This simplifies needing to act on a popup when there are more than one
on a page. Rather than passing a reference around the script, one can
get the reference from the popup's controller and target