### PR TITLE
Remove event listeners on ariaDestroy

### DIFF
--- a/src/plugins/AriaPopup.js
+++ b/src/plugins/AriaPopup.js
@@ -285,6 +285,10 @@ export default class AriaPopup extends Aria {
       child.removeAttribute('tabindex');
     });
 
+    this.controller.removeEventListener('click', this.ariaToggle);
+    this.target.removeEventListener('keydown', this.keyDownHandler);
+    document.body.removeEventListener('click', this.outsideClick);
+
     let destroy = null;
     const detail = { expanded: this.isExpanded };
     destroy = Aria.createAriaEvent('popupdestroy', detail);


### PR DESCRIPTION
I noticed event listeners aren't being removed when the popup is `ariaDestroy`ed...