### PR TITLE
Removes first item focus for popups

### DIFF
--- a/src/plugins/AriaPopup.js
+++ b/src/plugins/AriaPopup.js
@@ -211,7 +211,6 @@ export default class AriaPopup extends Aria {
     if (this.isExpanded) {
       this.collectInteractiveChildren();
       this.rovingTabIndex();
-      this.setFocusToFirstItem();
     } else {
       this.rovingTabIndex();
     }


### PR DESCRIPTION
I'd previously read the first item should have focus when a popup is opened, but after reading more I've seen advice to not do it. And since the popup's first item is already set as next in the tab order, I agree it makes sense to allow the user to manage focus.