### PR TITLE
Adds support for a custom selector via `config.root`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 3.1.0
 
+**Added**
+
+* Adds support for a custom selector via the `config.root` property
+
 **Fixed**
 
 * Component elements are collected from within the function created by `componentProvider`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Fixed**
 
 * Component elements are collected from within the function created by `componentProvider`
+* `domContentLoaded` now checks for an interactive document `readyState`
 
 ## 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Component elements are denoted by a `data-component` attribute, the value of whi
 
 ### The Configuration Object
 
-**name**: _(Required)_ - The component name. This must match the component root element's `data-component` attribute value.
+ **name**: _(Required if `root` isn't defined)_ - The component name. This must match the component root element's `data-component` attribute value.
+
+**root**: _(Optional)_ - The selector for the component root. Must be a valid CSS selector string used by `querySelector()`. Will be ignored if `name` is defined.
 
 **component**: _(Required)_ - A component can be created as an ES6 class or a function. This property accepts the exported class or function to be initialized for the component.
 

--- a/src/componentProvider.js
+++ b/src/componentProvider.js
@@ -33,7 +33,7 @@ export default function componentProvider(config) {
    * Collects component elements and passes them to each instance of the component.
    */
   const init = () => {
-    let componentEls = [];
+    let componentEls;
 
     // Test for a valid selector.
     try {

--- a/src/componentProvider.js
+++ b/src/componentProvider.js
@@ -19,8 +19,10 @@ export default function componentProvider(config) {
     return undefined;
   }
 
-  // The component selector.
-  const selector = `[data-component='${name}']`;
+  // Set component selector, preferring the `name` property.
+  const selector = (undefined === name)
+    ? config?.root
+    : `[data-component='${name}']`;
 
   // Get options.
   const options = config.options || {};
@@ -31,10 +33,18 @@ export default function componentProvider(config) {
    * Collects component elements and passes them to each instance of the component.
    */
   const init = () => {
-    const componentEls = document.querySelectorAll(selector);
+    let componentEls = [];
 
+    // Test for a valid selector.
+    try {
+      componentEls = document.querySelectorAll(selector);
+    } catch(e) {
+      console.error(e); // eslint-disable-line no-console
+      return undefined;
+    }
+
+    // No component elements found.
     if (componentEls.length < 1) {
-      // Do nothing.
       console.log(`No elements found for ${selector}`); // eslint-disable-line no-console
       return undefined;
     }

--- a/src/componentProvider.test.js
+++ b/src/componentProvider.test.js
@@ -2,7 +2,7 @@
 import componentProvider from './componentProvider';
 
 document.body.innerHTML = `
-  <div id="test-one" data-component="test-one">
+  <div id="test-one" class="wp-block-test-one" data-component="test-one">
     <button class="cool-button">Cool Button!</button>
     <ul>
       <li>First List Item</li>
@@ -172,6 +172,14 @@ test('Provides an empty options object when options are undefined', () => {
 
 test('Allows minimal config', () => {
   const config = { name: 'test-one', component: jest.fn() };
+
+  componentProvider(config);
+  expect(config.component).toHaveBeenCalledTimes(1);
+  expect(config.component).toHaveBeenCalledWith({ element, children: {}, options: {} });
+});
+
+test('Allows a custom selector', () => {
+  const config = { root: '.wp-block-test-one', component: jest.fn() };
 
   componentProvider(config);
   expect(config.component).toHaveBeenCalledTimes(1);

--- a/src/domContentLoaded.js
+++ b/src/domContentLoaded.js
@@ -4,7 +4,7 @@
  * @param {function} cb Callback to execute once DOMContentLoaded completes.
  */
 const domContentLoaded = (cb) => {
-  if (document.readyState === 'complete') {
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
     cb();
   }
 


### PR DESCRIPTION
This PR loosens the component selector restriction to allow any valid CSS selector to be used as the component root.

If `config.name` is defined, it will be used to match one or more instances of `data-component` attribute values; for backward compatibility, `config.name` is used if both `config.name` and `config.root` are defined.