### PR TITLE
Adds a `domContentLoaded` check for interactive `readyState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 **Fixed**
 
 * Component elements are collected from within the function created by `componentProvider`
+* `domContentLoaded` now checks for an interactive document `readyState`
 
 ## 3.0.0
 

--- a/src/domContentLoaded.js
+++ b/src/domContentLoaded.js
@@ -4,7 +4,7 @@
  * @param {function} cb Callback to execute once DOMContentLoaded completes.
  */
 const domContentLoaded = (cb) => {
-  if (document.readyState === 'complete') {
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
     cb();
   }
 


### PR DESCRIPTION
The `interactive` state indicates that the `DOMContentLoaded` event is about to fire.
https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState