### PR TITLE
Fix exports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,5 +23,6 @@
     "react": {
       "version": "999.999.999"
     }
-  }
+  },
+  "ignorePatterns": [ "**/*.md" ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Component elements are collected from within the function created by `componentProvider`
 * `domContentLoaded` now checks for an interactive document `readyState`
+* Importing from `v2/` will now work correctly
 
 ## 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -114,12 +114,6 @@ const productDetailsConfig = {
 componentProvider(productDetailsConfig);
 ```
 
-When using a bundler like webpack, import the ES module for a smaller footprint:
-
-```javascript
-import { componentProvider } from 'js-component-framework/es';
-```
-
 ### componentLoader
 
 `componentLoader` is used by `componentProvider` to load components. It is exported individually for cases where one doesn't want `componentProvider` to load the provider function automatically.

--- a/package.json
+++ b/package.json
@@ -56,14 +56,14 @@
     "not IE 11"
   ],
   "exports": {
-    ".": {
-      "import": "./es/index.js",
-      "default": "./lib/index.js"
-    },
+    "./es": "./es/index.js",
     "./v2": {
       "import": "./es/v2/index.js",
       "default": "./lib/v2/index.js"
     },
-    "./es": "./es/index.js"
+    ".": {
+      "import": "./es/index.js",
+      "default": "./lib/index.js"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,5 +54,16 @@
   "browserslist": [
     "defaults",
     "not IE 11"
-  ]
+  ],
+  "exports": {
+    ".": {
+      "import": "./es/index.js",
+      "default": "./lib/index.js"
+    },
+    "./v2": {
+      "import": "./es/v2/index.js",
+      "default": "./lib/v2/index.js"
+    },
+    "./es": "./es/index.js"
+  }
 }

--- a/src/v2/README.md
+++ b/src/v2/README.md
@@ -71,12 +71,6 @@ Component elements are denoted by a `data-component` attribute, the value of whi
 import { Component } from 'js-component-framework/v2';
 ```
 
-When using a bundler like webpack, import the ES module for a smaller footprint:
-
-```javascript
-import { Component } from 'js-component-framework/es/v2';
-```
-
 ❗️ A constructor is **required**. At minimum, the constructor should look like the following:
 
 ```javascript


### PR DESCRIPTION
While testing other updates slated for v3.1.0 I noticed importing from `js-component-framework/v2` produced a **Module not found** error.

1. With the `module` field present, ES6-aware tools will import the ES6 module version directly. No need for developers to be explicit about which export they want.
2. Importing from the `v2/` endpoint simply does not currently work. We need to supply an export for it to be accessible.
3. Adds a patch for the `es/` endpoint to avoid breaking changes.

[More info](https://nodejs.org/api/packages.html#conditional-exports)

I published this as `v3.1.0-beta.2` and tested all exports, including upgrading an existing project using `3.0.0`, with no issues.

```
npm install js-component-framework@beta
```