### PR TITLE
Corrects the domContentLoaded handler for deferred and async scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 3.1.1
+## 3.2.0
+
+**Added**
+
+* Setting `config.load` to `true` adds the provider function call inline so it is executed as soon as the parent script is parsed and loaded.
 
 **Fixed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 **Added**
 
-* Setting `config.load` to `true` adds the provider function call inline so it is executed as soon as the parent script is parsed and loaded.
+* Setting `config.load` to `true` adds the provider function call in place so it is executed as soon as the parent script is parsed and loaded.
 
 **Fixed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 3.1.1
+
+**Fixed**
+
+* The `domContentLoaded` function no longer executes its callback more than once
+
 ## 3.1.0
 
 **Added**

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ function productDetails({ element, children, options }) { ... }
 const productDetailsConfig = {
   name: 'product-details',
   component: productDetails,
-  // load: false | array | function
+  // load: boolean | array | function
   querySelectorAll: {
     toggles: '.product-details__toggle',
   },

--- a/README.md
+++ b/README.md
@@ -49,12 +49,12 @@ Component elements are denoted by a `data-component` attribute, the value of whi
 
 **options**: _(Optional)_ - An arbitrary value, typically an object, used by the component. This could be a configuration for another JS library, values used for calculating styles, etc. This is passed to the wrapped function as the `options` property.
 
-**load**: _(Optional)_ - Accepts `false`, array, or a callback. _Default is a `domContentLoaded` callback_.
+**load**: _(Optional)_ - _Default is a `DOMContentLoaded` handler_.
 
-* `false` will disable loading and instruct `componentProvider` to return the provider function
-* An array, in the format of `[HTMLElement, event]`, will listen on `HTMLElement` for `event` (e.g., `[window, 'load']`)
-* A callback that accepts a function and contains the logic to call the function
-
+* `false` - prevents execution and instructs `componentProvider` to return the provider function
+* `true` - Adds the provider function call inline so it is executed as soon as the parent script is parsed and loaded.
+* `array` - `[HTMLElement, event]` - Adds the provider function as a callback for `event` on `HTMLElement` (e.g., `[window, 'load']`).
+* `handler` - A function that accepts a callback and contains the logic to call it.
 ### Component Properties
 
 Components receive an object of component properties as their only argument. These are based on the config and are included automatically by the framework.
@@ -111,6 +111,7 @@ const productDetailsConfig = {
   },
 };
 
+// The component is executed at 'DOMContentLoaded' due to the absense of a `config.load` value.
 componentProvider(productDetailsConfig);
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Component elements are denoted by a `data-component` attribute, the value of whi
 **load**: _(Optional)_ - _Default is a `DOMContentLoaded` handler_.
 
 * `false` - prevents execution and instructs `componentProvider` to return the provider function
-* `true` - Adds the provider function call inline so it is executed as soon as the parent script is parsed and loaded.
+* `true` - Adds the provider function call in place so it is executed as soon as the parent script is parsed and loaded.
 * `array` - `[HTMLElement, event]` - Adds the provider function as a callback for `event` on `HTMLElement` (e.g., `[window, 'load']`).
 * `handler` - A function that accepts a callback and contains the logic to call it.
 ### Component Properties

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-component-framework",
-  "version": "3.1.0",
+  "version": "3.2.0-beta.1",
   "description": "A framework for configuring a JavaScript component and attaching it to a DOM element or collection of DOM elements, simplifying organization of DOM interactions on your website.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "js-component-framework",
-  "version": "3.2.0-beta.1",
+  "version": "3.2.0",
   "description": "A framework for configuring a JavaScript component and attaching it to a DOM element or collection of DOM elements, simplifying organization of DOM interactions on your website.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/componentLoader.test.js
+++ b/src/componentLoader.test.js
@@ -10,7 +10,7 @@ const providerFunc = jest.fn();
 
 test('Does not call the provider function with `load:false`', () => {
   componentLoader(providerFunc, false);
-  expect(providerFunc).toHaveBeenCalledTimes(0);
+  expect(providerFunc).not.toHaveBeenCalled();
 });
 
 test('Does not call the provider function with `load:true`', () => {
@@ -27,7 +27,7 @@ test('Calls the provider function with the loader function', () => {
 
 test('Loads on event for single instance', () => {
   componentLoader(providerFunc, [eventRoot, 'jscf-test-event']);
-  expect(providerFunc).toHaveBeenCalledTimes(0);
+  expect(providerFunc).not.toHaveBeenCalled();
 
   eventRoot.dispatchEvent(new CustomEvent('jscf-test-event'));
   expect(providerFunc).toHaveBeenCalledTimes(1);
@@ -35,14 +35,14 @@ test('Loads on event for single instance', () => {
 
 test('Fails silently on invalid event config', () => {
   componentLoader(providerFunc, [null, 'jscf-null-test']);
-  expect(providerFunc).toHaveBeenCalledTimes(0);
+  expect(providerFunc).not.toHaveBeenCalled();
 
   eventRoot.dispatchEvent(new CustomEvent('jscf-null-test'));
-  expect(providerFunc).toHaveBeenCalledTimes(0);
+  expect(providerFunc).not.toHaveBeenCalled();
 
   componentLoader(providerFunc, [eventRoot, 123]);
-  expect(providerFunc).toHaveBeenCalledTimes(0);
+  expect(providerFunc).not.toHaveBeenCalled();
 
   eventRoot.dispatchEvent(new CustomEvent('jscf-fail-test'));
-  expect(providerFunc).toHaveBeenCalledTimes(0);
+  expect(providerFunc).not.toHaveBeenCalled();
 });

--- a/src/componentLoader.test.js
+++ b/src/componentLoader.test.js
@@ -13,6 +13,11 @@ test('Does not call the provider function with `load:false`', () => {
   expect(providerFunc).toHaveBeenCalledTimes(0);
 });
 
+test('Does not call the provider function with `load:true`', () => {
+  componentLoader(providerFunc, true);
+  expect(providerFunc).not.toHaveBeenCalled();
+});
+
 test('Calls the provider function with the loader function', () => {
   const loader = jest.fn((func) => func());
 

--- a/src/componentProvider.js
+++ b/src/componentProvider.js
@@ -86,7 +86,7 @@ export default function componentProvider(config) {
    * Call the provider function so it is executed as soon as the document is
    * parsed and loaded.
    *
-   * This is a conventience option and is functionally identical to setting
+   * This is a convenience option and is functionally identical to setting
    * `config.load` to false and calling the provider function later in the script.
    */
   if (load === true) {

--- a/src/componentProvider.js
+++ b/src/componentProvider.js
@@ -83,7 +83,8 @@ export default function componentProvider(config) {
   }
 
   /*
-   * Call the provider function so it is executed as soon as the document is parsed.
+   * Call the provider function so it is executed as soon as the document is
+   * parsed and loaded.
    *
    * This is a conventience option and is functionally identical to setting
    * `config.load` to false and calling the provider function later in the script.

--- a/src/componentProvider.js
+++ b/src/componentProvider.js
@@ -93,6 +93,6 @@ export default function componentProvider(config) {
     return void init(); // eslint-disable-line no-void
   }
 
-  // Use the function defined in the `load` config property.
+  // Use the handler defined in the `load` config property.
   return void componentLoader(init, load); // eslint-disable-line no-void
 }

--- a/src/componentProvider.js
+++ b/src/componentProvider.js
@@ -77,12 +77,21 @@ export default function componentProvider(config) {
     componentArgs.forEach((args) => new Component(args));
   };
 
-  if (load !== false) {
-    // Load the provider function.
-    componentLoader(init, load);
-
-    return undefined;
+  // Return the provider function for later execution.
+  if (load === false) {
+    return init;
   }
 
-  return init;
+  /*
+   * Call the provider function so it is executed as soon as the document is parsed.
+   *
+   * This is a conventience option and is functionally identical to setting
+   * `config.load` to false and calling the provider function later in the script.
+   */
+  if (load === true) {
+    return void init(); // eslint-disable-line no-void
+  }
+
+  // Use the function defined in the `load` config property.
+  return void componentLoader(init, load); // eslint-disable-line no-void
 }

--- a/src/componentProvider.test.js
+++ b/src/componentProvider.test.js
@@ -115,6 +115,20 @@ test('Returns the expected function for multiple instances when `load:false`', (
   expect(config.component).toHaveBeenNthCalledWith(2, testTwoExpected[1]);
 });
 
+test('Calls the component immediately when `load:true`', () => {
+  const config = { ...baseConfig, name: 'test-one', load: true };
+
+  componentProvider(config);
+  expect(config.component).toHaveBeenCalledTimes(1);
+});
+
+test('Calls the component for multiple instances immediately when `load:true`', () => {
+  const config = { ...baseConfig, name: 'test-two', load: true };
+
+  componentProvider(config);
+  expect(config.component).toHaveBeenCalledTimes(2);
+});
+
 test('Loads on event for single instance', () => {
   const config = {
     ...baseConfig,

--- a/src/componentProvider.test.js
+++ b/src/componentProvider.test.js
@@ -106,6 +106,7 @@ test('Returns the expected function for multiple instances when `load:false`', (
   const config = { ...baseConfig, name: 'test-two', load: false };
 
   const providerFunction = componentProvider(config);
+  expect(typeof providerFunction).toBe('function');
   expect(config.component).toHaveBeenCalledTimes(0);
 
   providerFunction();

--- a/src/componentProvider.test.js
+++ b/src/componentProvider.test.js
@@ -119,7 +119,8 @@ test('Returns the expected function for multiple instances when `load:false`', (
 test('Calls the component immediately when `load:true`', () => {
   const config = { ...baseConfig, name: 'test-one', load: true };
 
-  componentProvider(config);
+  const providerFunction = componentProvider(config);
+  expect(providerFunction).toBeUndefined();
   expect(config.component).toHaveBeenCalledTimes(1);
 });
 

--- a/src/componentProvider.test.js
+++ b/src/componentProvider.test.js
@@ -95,7 +95,7 @@ test('Returns the expected function for single instance when `load:false`', () =
   const config = { ...baseConfig, name: 'test-one', load: false };
 
   const providerFunction = componentProvider(config);
-  expect(config.component).toHaveBeenCalledTimes(0);
+  expect(config.component).not.toHaveBeenCalled();
 
   providerFunction();
   expect(config.component).toHaveBeenCalledTimes(1);
@@ -107,7 +107,7 @@ test('Returns the expected function for multiple instances when `load:false`', (
 
   const providerFunction = componentProvider(config);
   expect(typeof providerFunction).toBe('function');
-  expect(config.component).toHaveBeenCalledTimes(0);
+  expect(config.component).not.toHaveBeenCalled();
 
   providerFunction();
   expect(config.component).toHaveBeenCalledTimes(2);
@@ -138,7 +138,7 @@ test('Loads on event for single instance', () => {
   };
 
   componentProvider(config);
-  expect(config.component).toHaveBeenCalledTimes(0);
+  expect(config.component).not.toHaveBeenCalled();
 
   eventRoot.dispatchEvent(new CustomEvent('jscf-test-one-event'));
   expect(config.component).toHaveBeenCalledTimes(1);
@@ -153,7 +153,7 @@ test('Loads on event for multiple instances', () => {
   };
 
   componentProvider(config);
-  expect(config.component).toHaveBeenCalledTimes(0);
+  expect(config.component).not.toHaveBeenCalled();
 
   eventRoot.dispatchEvent(new CustomEvent('jscf-test-two-event'));
   expect(config.component).toHaveBeenCalledTimes(2);
@@ -170,10 +170,10 @@ test('Fails silently on `null` event root', () => {
   };
 
   componentProvider(config);
-  expect(config.component).toHaveBeenCalledTimes(0);
+  expect(config.component).not.toHaveBeenCalled();
 
   eventRoot.dispatchEvent(new CustomEvent('jscf-null-test'));
-  expect(config.component).toHaveBeenCalledTimes(0);
+  expect(config.component).not.toHaveBeenCalled();
 });
 
 test('Provides an empty options object when options are undefined', () => {

--- a/src/domContentLoaded.js
+++ b/src/domContentLoaded.js
@@ -1,17 +1,19 @@
+/* eslint consistent-return: ["error", { "treatUndefinedAsUnspecified": true }] */
+
 /**
  * Executes the given callback when DOMContentLoaded is ready.
  *
- * @param {function} cb Callback to execute once DOMContentLoaded completes.
+ * @param {function} callback Callback to execute once DOMContentLoaded completes.
  */
-const domContentLoaded = (cb) => {
+function domContentLoaded(callback) {
   if (
     document.readyState === 'complete'
     || document.readyState === 'interactive'
   ) {
-    cb();
+    return void callback(); // eslint-disable-line no-void
   }
 
-  document.addEventListener('DOMContentLoaded', cb, { once: true });
-};
+  document.addEventListener('DOMContentLoaded', callback, { once: true });
+}
 
 export default domContentLoaded;

--- a/src/domContentLoaded.test.js
+++ b/src/domContentLoaded.test.js
@@ -1,0 +1,48 @@
+import domContentLoaded from './domContentLoaded';
+
+// Mocks.
+const providerFunc = jest.fn();
+const addEventListener = jest.fn(() => {});
+
+beforeAll(() => {
+  // Allows setting document.readyState.
+  Object.defineProperty(document, 'readyState', {
+    value: 'loading',
+    writable: true,
+  });
+
+  Object.defineProperty(document, 'addEventListener', {
+    value: addEventListener,
+  });
+});
+
+afterEach(() => jest.clearAllMocks());
+
+test("'loading' readyState uses DOMContentLoaded", () => {
+  domContentLoaded(providerFunc);
+  expect(providerFunc).not.toHaveBeenCalled();
+
+  expect(addEventListener).toHaveBeenCalledWith(
+    'DOMContentLoaded',
+    providerFunc,
+    { once: true },
+  );
+});
+
+test("'complete' readyState calls the function immediately", () => {
+  document.readyState = 'complete';
+
+  domContentLoaded(providerFunc);
+  expect(providerFunc).toHaveBeenCalledTimes(1);
+
+  expect(addEventListener).not.toHaveBeenCalled();
+});
+
+test("'interactive' readyState calls the funciton immediately", () => {
+  document.readyState = 'interactive';
+
+  domContentLoaded(providerFunc);
+  expect(providerFunc).toHaveBeenCalledTimes(1);
+
+  expect(addEventListener).not.toHaveBeenCalled();
+});

--- a/src/domContentLoaded.test.js
+++ b/src/domContentLoaded.test.js
@@ -1,6 +1,5 @@
 import domContentLoaded from './domContentLoaded';
 
-// Mocks.
 const providerFunc = jest.fn();
 const addEventListener = jest.fn(() => {});
 


### PR DESCRIPTION
The bug in the issue is cause by the callback being called and _also_ being added as a callback for the `'DOMContentLoaded'` event. I provide the following solutions for the issue, the second of which is in place for edge cases for which the first isn't effective.

1. Corrects `domContentLoaded` to return when `document.readyState` is `'complete'` or `'interactive'`, which prevents the callback from running more than once
2. Adds a new `true` option for `config.load` to add the provider function call inline so it is executed as soon as the parent script is parsed and loaded.

Fixes #43 